### PR TITLE
fix: fix .fs file package directory

### DIFF
--- a/src/build/Fable.Package.SDK.targets
+++ b/src/build/Fable.Package.SDK.targets
@@ -10,7 +10,7 @@
         <ItemGroup>
             <_PackageFiles Include="@(Compile)">
                 <Pack>true</Pack>
-                <PackagePath>fable/%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
+                <PackagePath>fable/%(RelativeDir)%(Filename)%(Extension)</PackagePath>
                 <BuildAction>None</BuildAction>
             </_PackageFiles>
 

--- a/tests/Main.fs
+++ b/tests/Main.fs
@@ -321,3 +321,31 @@ let ``should include the source file and the project file under 'fable' folder -
 
         Assert.That(entries, Contains.Item("fable/MyLibraryMultiTFM.fsproj"))
     }
+
+[<Test>]
+let ``should include the sources files by respecting the folder structure and the project file under 'fable' folder`` () =
+    task {
+        // Make sure we work with a fresh nupkg file
+        let fileInfo =
+            VirtualWorkspace.fixtures.valid.``library-with-files-and-folder``.bin.Release.``MyLibrary.1.0.0.nupkg``
+            |> FileInfo
+
+        if fileInfo.Exists then
+            fileInfo.Delete()
+
+        Command.Run(
+            "dotnet",
+            $"pack %s{Workspace.fixtures.valid.``library-with-files-and-folder``.``MyLibrary.fsproj``}"
+        )
+
+        let archive =
+            ZipFile.OpenRead(
+                VirtualWorkspace.fixtures.valid.``library-with-files-and-folder``.bin.Release.``MyLibrary.1.0.0.nupkg``
+            )
+
+        let entries = archive.Entries |> Seq.map (fun entry -> entry.FullName) |> Seq.toList
+
+        Assert.That(entries, Contains.Item("fable/Entry.fs"))
+        Assert.That(entries, Contains.Item("fable/Global/Version.fs"))
+        Assert.That(entries, Contains.Item("fable/MyLibrary.fsproj"))
+    }

--- a/tests/Workspace.fs
+++ b/tests/Workspace.fs
@@ -18,4 +18,8 @@ fixtures/
             bin/
                 Release/
                     MyLibraryMultiTFM.1.0.0.nupkg
+        library-with-files-and-folder/
+            bin/
+                Release/
+                    MyLibrary.1.0.0.nupkg
 """>

--- a/tests/fixtures/valid/library-with-files-and-folder/Entry.fs
+++ b/tests/fixtures/valid/library-with-files-and-folder/Entry.fs
@@ -1,0 +1,3 @@
+module MyLibrary
+
+let answer = 42

--- a/tests/fixtures/valid/library-with-files-and-folder/Global/Version.fs
+++ b/tests/fixtures/valid/library-with-files-and-folder/Global/Version.fs
@@ -1,0 +1,3 @@
+module Global
+
+let version = "1.0.0"

--- a/tests/fixtures/valid/library-with-files-and-folder/MyLibrary.fsproj
+++ b/tests/fixtures/valid/library-with-files-and-folder/MyLibrary.fsproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <FablePackageType>library</FablePackageType>
+        <PackageTags>fable-javascript</PackageTags>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="Global/Version.fs" />
+        <Compile Include="Entry.fs" />
+    </ItemGroup>
+    <Import Project="./../../Fable.Package.SDK.Imports.props" />
+</Project>


### PR DESCRIPTION
The %(RecursiveDir) is empty for the @(Compile) property.

To get .fs files in the correct directory, it now uses %(RelativeDir).

Without it, relative path inside the nuget are broken, making it not usable.